### PR TITLE
[Custom Time Input] Fixing issues with the pattern

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+.vercel

--- a/src/components/Countdown/index.jsx
+++ b/src/components/Countdown/index.jsx
@@ -61,13 +61,13 @@ class Countdown extends React.Component {
   }
 
   handleInputTime({ target }) {
-    const temporaryTime = target.value;
-                         
-    const timePattern = /^(([1-9]|[1-5][0-9])m\s?)?(([1-9]|[1-5][0-9])s)?$/;
+    const { validateCustomTimeInput } = timeFunctions;
+
+    const isValid = validateCustomTimeInput(target.value);
 
     this.setState({
       temporaryTime: target.value,
-      startCountdownDisabled: !temporaryTime.match(timePattern),
+      startCountdownDisabled: !isValid,
     });
   }
 

--- a/src/components/Preferences/components/TimePreset/index.jsx
+++ b/src/components/Preferences/components/TimePreset/index.jsx
@@ -29,15 +29,19 @@ export default class TimePreset extends Component {
   }
 
   handleInputTime({ target }) {
-    const { convertCustomTimeToSeconds, setPreset } = timeFunctions;
+    const {
+      convertCustomTimeToSeconds,
+      setPreset,
+      validateCustomTimeInput,
+    } = timeFunctions;
     const temporaryTime = target.value;
     const { name: nameInState } = this.state;
     const { label } = this.props;
     const name = nameInState || label;
 
-    const timePattern = /^([1-5][0-9]|[1-9])m\s([1-5][0-9]|[1-9])+s$|^([1-5][0-9]|[1-9])(m|s)$/g;
+    const isValid = validateCustomTimeInput(temporaryTime);
 
-    if (temporaryTime.match(timePattern)) {
+    if (isValid) {
       const time = convertCustomTimeToSeconds(temporaryTime);
       this.setState({ isValueValid: true });
       setPreset(name, time);

--- a/src/functions/time.js
+++ b/src/functions/time.js
@@ -83,9 +83,16 @@ function convertCustomTimeToSeconds(temporaryTime) {
   return seconds;
 }
 
+function validateCustomTimeInput(timeToValidate) {
+  const timePattern = /^([1-5][0-9]|[1-9])m\s([1-5][0-9]|[1-9])s$|^([1-5][0-9]|[1-9])(m|s)$/;
+
+  return timeToValidate.match(timePattern);
+}
+
 export default {
   getPreset,
   convertTimeToMinutesAndSeconds,
   setPreset,
   convertCustomTimeToSeconds,
+  validateCustomTimeInput,
 };


### PR DESCRIPTION
This PR is about to solve the issue of "3m25s" being accepted. The only format to be acceptable is "3m 25s". I believe that rule should drive the user to type only that way, avoiding experience issues.
A time function was created to validate custom time inputs with the regex. It allows the same regex pattern to be used for validation in any part of the application.